### PR TITLE
Add CI gate job

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -58,3 +58,16 @@ jobs:
       is_fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       github_access_token: ${{ secrets.github_access_token }}
+
+  ci_gate:
+    if: ${{ always() }}
+    name: gate
+    needs: [ ci_terraform, ci_readme, ci_codeowners ]
+    steps:
+      - run: exit 1
+        # see https://stackoverflow.com/a/67532120/4907315
+        if: >-
+          ${{
+               contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+          }}


### PR DESCRIPTION
## what
* Add CI gate job

## why
* Summarize all builds incl. matrix to avoid them leaking into branch protection rules

## references
- https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
- https://github.com/orgs/community/discussions/26822

