### PR TITLE
Combined scheduled workflow for terraform module

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -1,5 +1,5 @@
 name: |-
-  Features Branch (Pull Request) Workflow 
+  Features Branch (Pull Request) Workflow of a Terraform Module
   
   ### Usage 
   

--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -1,5 +1,5 @@
 name: |-
-  Features Branch (Pull Request) Workflow of a Terraform Module
+  Feature Branch (Pull Request) Workflow of a Terraform Module
   
   ### Usage 
   

--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -1,5 +1,5 @@
 name: |-
-  Main Branch Workflow
+  Main Branch Workflow of a Terraform Module
   
   ### Usage 
   

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -19,6 +19,8 @@ name: |-
     jobs:
       scheduled:
         uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/scheduled.yml@main
+        secrets:
+          github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
   ```
 
 on:
@@ -29,6 +31,10 @@ on:
         type: string
         required: false
         default: '["ubuntu-latest"]'
+    secrets:
+      github_access_token:
+        description: "GitHub API token"
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,8 +45,12 @@ jobs:
     uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-context.yml@main
     with:
       runs-on: ${{ inputs.runs-on }}
+    secrets:
+      github_access_token: ${{ secrets.github_access_token }}
 
   readme:
     uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-readme.yml@main
     with:
       runs-on: ${{ inputs.runs-on }}
+    secrets:
+      github_access_token: ${{ secrets.github_access_token }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -36,11 +36,11 @@ concurrency:
 
 jobs:
   context:
-    uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-context.yml@sched_workflows
+    uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-context.yml@main
     with:
       runs-on: ${{ inputs.runs-on }}
 
   readme:
-    uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-readme.yml@sched_workflows
+    uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-readme.yml@main
     with:
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -35,12 +35,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  update-context:
+  context:
     uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-context.yml@sched_workflows
     with:
       runs-on: ${{ inputs.runs-on }}
 
-  update-readme:
+  readme:
     uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-readme.yml@sched_workflows
     with:
       runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,7 +20,7 @@ name: |-
       scheduled:
         uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/scheduled.yml@main
         secrets:
-          github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          github_access_token: $\{\{ secrets.REPO_ACCESS_TOKEN \}\}
   ```
 
 on:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,0 +1,46 @@
+name: |-
+  Scheduled Workflows of a Terraform Module
+  
+  ### Usage 
+  
+  In your repo create  __`.github/workflows/scheduled.yaml`__
+  
+  ```yaml
+    name: scheduled
+    on:
+      schedule:
+        - cron: "30 0 * * *"
+  
+    permissions:
+      pull-requests: write
+      id-token: write
+      contents: read
+    
+    jobs:
+      scheduled:
+        uses: cloudposse/github-actions-workflows-terraform-module/.github/workflows/scheduled.yml@main
+  ```
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: "Overrides job runs-on setting (json-encoded list)"
+        type: string
+        required: false
+        default: '["ubuntu-latest"]'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  update-context:
+    uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-context.yml@sched_workflows
+    with:
+      runs-on: ${{ inputs.runs-on }}
+
+  update-readme:
+    uses: cloudposse/github-actions-workflows/.github/workflows/scheduled-readme.yml@sched_workflows
+    with:
+      runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,12 +9,12 @@ name: |-
     name: scheduled
     on:
       schedule:
-        - cron: "30 0 * * *"
+        - cron: "0 3 * * *"
   
     permissions:
       pull-requests: write
       id-token: write
-      contents: read
+      contents: write
     
     jobs:
       scheduled:


### PR DESCRIPTION
## what
* Combine all scheduled workflows for terraform module into one for easier distribution
* NOTE: when using this workflow you can't separate schedules of individual jobs. This does not affect terraform as we used the same schedule anyways. If separate schedule is still needed, you can still call individual workflows from github-actions-workflows repo directly.

## why
* Reducing terraform boilerplate

