### PR TITLE
Tflint set filter-mode to `diff_context`

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -49,7 +49,7 @@ jobs:
       # We should switch to nofilter once it's fixed
       # filter-mode: diff_context
       # suggestions: true
-      filter-mode: nofilter
+      filter-mode: diff_context
       suggestions: false      
       runs-on: ${{ inputs.runs-on }}
 


### PR DESCRIPTION
## what
* Tflint set filter-mode to `diff_context`

## why
* Report linting issues only related to PR changes
