### PR TITLE
Use github app for codeowners validation

### DIFF
--- a/.github/workflows/feature-branch.yml
+++ b/.github/workflows/feature-branch.yml
@@ -32,10 +32,6 @@ on:
         type: string
         required: false
         default: '["ubuntu-latest"]'
-    secrets:
-      REPO_ACCESS_TOKEN:
-        description: "GitHub API token"
-        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -52,12 +48,11 @@ jobs:
       runs-on: ${{ inputs.runs-on }}
 
   ci-codeowners:
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@main
+    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@codeowners-github-app
     with:
       is_fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
       runs-on: ${{ inputs.runs-on }}
-    secrets:
-      github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
+    secrets: inherit
 
   ci-labels:
     runs-on: ${{ fromJSON(inputs.runs-on) }}

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -32,10 +32,6 @@ on:
         type: string
         required: false
         default: '["ubuntu-latest"]'
-    secrets:
-      REPO_ACCESS_TOKEN:
-        description: "GitHub API token"
-        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -58,12 +54,11 @@ jobs:
     secrets: inherit
     
   ci-codeowners:
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@main
+    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@codeowners-github-app
     with:
       is_fork: false
       runs-on: ${{ inputs.runs-on }}
-    secrets:
-      github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
+    secrets: inherit
 
   auto-release:
     needs: [ci-terraform, ci-readme, ci-codeowners]


### PR DESCRIPTION
## what
* Use the GitHub app for code owners validation

## why
* Get rid of PAT for security reasons
* DEV-2144 Create GitHub app for code-owners testing

## references
* https://linear.app/cloudposse/issue/DEV-2144/create-github-app-for-code-owners-testing
