### PR TITLE
fix: remove unused release-branch inputs

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -52,8 +52,6 @@ jobs:
   ci-readme:
     uses: cloudposse/github-actions-workflows/.github/workflows/ci-readme.yml@main
     with:
-      filter-mode: nofilter
-      suggestions: false
       runs-on: ${{ inputs.runs-on }}
     secrets: inherit
     


### PR DESCRIPTION
## what

- remove inputs from `release-branch` workflow

## why

- workflow doesn't run with invalid inputs

## references

- cloudposse/github-actions-workflows#117
